### PR TITLE
Fix: 로그인 후 여행일기 페이지에 접속할 수 없는 오류 수정

### DIFF
--- a/src/app/api/auth/kakao/route.ts
+++ b/src/app/api/auth/kakao/route.ts
@@ -2,15 +2,15 @@ import { NextResponse } from "next/server";
 
 export function GET() {
   try {
-  const clientId = process.env.KAKAO_REST_API_KEY;
-  const redirectUri = process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URL;
-  const timestamp = new Date().toISOString(); // Get the current timestamp in ISO format
+    const clientId = process.env.KAKAO_REST_API_KEY;
+    const redirectUri = process.env.NEXT_PUBLIC_KAKAO_REDIRECT_URL;
+    const timestamp = new Date().toISOString(); // Get the current timestamp in ISO format
 
-  if (!clientId || !redirectUri) {
-    return NextResponse.redirect("/auth/signin");
-  }
+    if (!clientId || !redirectUri) {
+      return NextResponse.redirect("/auth/signin");
+    }
 
-  const kakaoAuthUrl = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${clientId}&redirect_uri=${redirectUri}&timestamp=${timestamp}`;
+    const kakaoAuthUrl = `https://kauth.kakao.com/oauth/authorize?response_type=code&client_id=${clientId}&redirect_uri=${redirectUri}&timestamp=${timestamp}`;
     return NextResponse.redirect(kakaoAuthUrl);
   } catch (error) {
     return NextResponse.redirect("/auth/signin");

--- a/src/components/common/Header.tsx
+++ b/src/components/common/Header.tsx
@@ -110,6 +110,7 @@ const Header = ({
                       } ` + "text-sm hover:text-main"
                     }
                     href="/diary/list"
+                    prefetch={userId > 0}
                   >
                     여행일기
                   </Link>
@@ -138,10 +139,7 @@ const Header = ({
               </>
             ) : userId > 0 ? (
               <>
-                <Link
-                  href={"/mypage"}
-                  className={"relative rounded-[50%]"}
-                >
+                <Link href={"/mypage"} className={"relative rounded-[50%]"}>
                   <Image
                     className="rounded-full shadow dark:bg-slate-200"
                     src="/user_sex_man_default_image.svg"


### PR DESCRIPTION
Header에 있는 여행일기 Link가 prefetch되면서 access_token과 refresh_token이 cookie에 저장되기 전에 미들웨어가 실행되는 문제가 있었습니다. 해당 문제를 authStore의 userId가 할당된 후 prefetch하는 것으로 수정하였습니다.